### PR TITLE
Fixed resizing on EditOcrResults window

### DIFF
--- a/RegulatedNoise/EditOcrResults.Designer.cs
+++ b/RegulatedNoise/EditOcrResults.Designer.cs
@@ -150,6 +150,7 @@
             // 
             this.EditOcrResultsSplit.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EditOcrResultsSplit.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.EditOcrResultsSplit.IsSplitterFixed = true;
             this.EditOcrResultsSplit.Location = new System.Drawing.Point(0, 0);
             this.EditOcrResultsSplit.Name = "EditOcrResultsSplit";
             this.EditOcrResultsSplit.Orientation = System.Windows.Forms.Orientation.Horizontal;

--- a/RegulatedNoise/EditOcrResults.Designer.cs
+++ b/RegulatedNoise/EditOcrResults.Designer.cs
@@ -38,19 +38,22 @@
             this.tbEditOcrResultsSupplyLevel = new System.Windows.Forms.TextBox();
             this.tbEditOcrResultsSupply = new System.Windows.Forms.TextBox();
             this.bEditOcrResultsOK = new System.Windows.Forms.Button();
+            this.EditOcrResultsSplit = new System.Windows.Forms.SplitContainer();
             ((System.ComponentModel.ISupportInitialize)(this.pbEditOcrResultsOriginalImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.EditOcrResultsSplit)).BeginInit();
+            this.EditOcrResultsSplit.Panel1.SuspendLayout();
+            this.EditOcrResultsSplit.Panel2.SuspendLayout();
+            this.EditOcrResultsSplit.SuspendLayout();
             this.SuspendLayout();
             // 
             // lbEditOcrResults
             // 
-            this.lbEditOcrResults.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lbEditOcrResults.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lbEditOcrResults.FormattingEnabled = true;
-            this.lbEditOcrResults.Location = new System.Drawing.Point(9, 9);
+            this.lbEditOcrResults.Location = new System.Drawing.Point(0, 0);
             this.lbEditOcrResults.Name = "lbEditOcrResults";
             this.lbEditOcrResults.ScrollAlwaysVisible = true;
-            this.lbEditOcrResults.Size = new System.Drawing.Size(1058, 160);
+            this.lbEditOcrResults.Size = new System.Drawing.Size(1079, 168);
             this.lbEditOcrResults.TabIndex = 0;
             this.lbEditOcrResults.SelectedIndexChanged += new System.EventHandler(this.lbEditOcrResults_SelectedIndexChanged);
             // 
@@ -59,9 +62,9 @@
             this.pbEditOcrResultsOriginalImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.pbEditOcrResultsOriginalImage.Location = new System.Drawing.Point(12, 175);
+            this.pbEditOcrResultsOriginalImage.Location = new System.Drawing.Point(12, 3);
             this.pbEditOcrResultsOriginalImage.Name = "pbEditOcrResultsOriginalImage";
-            this.pbEditOcrResultsOriginalImage.Size = new System.Drawing.Size(1055, 29);
+            this.pbEditOcrResultsOriginalImage.Size = new System.Drawing.Size(1043, 35);
             this.pbEditOcrResultsOriginalImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pbEditOcrResultsOriginalImage.TabIndex = 1;
             this.pbEditOcrResultsOriginalImage.TabStop = false;
@@ -69,7 +72,7 @@
             // tbEditOcrResultsCommodityName
             // 
             this.tbEditOcrResultsCommodityName.Font = new System.Drawing.Font("Arial Narrow", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsCommodityName.Location = new System.Drawing.Point(62, 210);
+            this.tbEditOcrResultsCommodityName.Location = new System.Drawing.Point(55, 44);
             this.tbEditOcrResultsCommodityName.Name = "tbEditOcrResultsCommodityName";
             this.tbEditOcrResultsCommodityName.Size = new System.Drawing.Size(315, 34);
             this.tbEditOcrResultsCommodityName.TabIndex = 2;
@@ -78,7 +81,7 @@
             // tbEditOcrResultsSellPrice
             // 
             this.tbEditOcrResultsSellPrice.Font = new System.Drawing.Font("Arial", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsSellPrice.Location = new System.Drawing.Point(383, 210);
+            this.tbEditOcrResultsSellPrice.Location = new System.Drawing.Point(376, 44);
             this.tbEditOcrResultsSellPrice.Name = "tbEditOcrResultsSellPrice";
             this.tbEditOcrResultsSellPrice.Size = new System.Drawing.Size(100, 34);
             this.tbEditOcrResultsSellPrice.TabIndex = 3;
@@ -88,7 +91,7 @@
             // tbEditOcrResultsBuyPrice
             // 
             this.tbEditOcrResultsBuyPrice.Font = new System.Drawing.Font("Arial", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsBuyPrice.Location = new System.Drawing.Point(489, 210);
+            this.tbEditOcrResultsBuyPrice.Location = new System.Drawing.Point(482, 44);
             this.tbEditOcrResultsBuyPrice.Name = "tbEditOcrResultsBuyPrice";
             this.tbEditOcrResultsBuyPrice.Size = new System.Drawing.Size(82, 34);
             this.tbEditOcrResultsBuyPrice.TabIndex = 4;
@@ -98,7 +101,7 @@
             // tbEditOcrResultsDemand
             // 
             this.tbEditOcrResultsDemand.Font = new System.Drawing.Font("Arial", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsDemand.Location = new System.Drawing.Point(650, 210);
+            this.tbEditOcrResultsDemand.Location = new System.Drawing.Point(640, 43);
             this.tbEditOcrResultsDemand.Name = "tbEditOcrResultsDemand";
             this.tbEditOcrResultsDemand.Size = new System.Drawing.Size(133, 34);
             this.tbEditOcrResultsDemand.TabIndex = 5;
@@ -108,7 +111,7 @@
             // tbEditOcrResultsDemandLevel
             // 
             this.tbEditOcrResultsDemandLevel.Font = new System.Drawing.Font("Arial Narrow", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsDemandLevel.Location = new System.Drawing.Point(786, 210);
+            this.tbEditOcrResultsDemandLevel.Location = new System.Drawing.Point(779, 43);
             this.tbEditOcrResultsDemandLevel.Name = "tbEditOcrResultsDemandLevel";
             this.tbEditOcrResultsDemandLevel.Size = new System.Drawing.Size(57, 34);
             this.tbEditOcrResultsDemandLevel.TabIndex = 6;
@@ -117,7 +120,7 @@
             // tbEditOcrResultsSupplyLevel
             // 
             this.tbEditOcrResultsSupplyLevel.Font = new System.Drawing.Font("Arial Narrow", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsSupplyLevel.Location = new System.Drawing.Point(977, 210);
+            this.tbEditOcrResultsSupplyLevel.Location = new System.Drawing.Point(973, 43);
             this.tbEditOcrResultsSupplyLevel.Name = "tbEditOcrResultsSupplyLevel";
             this.tbEditOcrResultsSupplyLevel.Size = new System.Drawing.Size(57, 34);
             this.tbEditOcrResultsSupplyLevel.TabIndex = 8;
@@ -126,7 +129,7 @@
             // tbEditOcrResultsSupply
             // 
             this.tbEditOcrResultsSupply.Font = new System.Drawing.Font("Arial", 17.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbEditOcrResultsSupply.Location = new System.Drawing.Point(849, 210);
+            this.tbEditOcrResultsSupply.Location = new System.Drawing.Point(842, 44);
             this.tbEditOcrResultsSupply.Name = "tbEditOcrResultsSupply";
             this.tbEditOcrResultsSupply.Size = new System.Drawing.Size(125, 34);
             this.tbEditOcrResultsSupply.TabIndex = 7;
@@ -135,7 +138,7 @@
             // 
             // bEditOcrResultsOK
             // 
-            this.bEditOcrResultsOK.Location = new System.Drawing.Point(929, 250);
+            this.bEditOcrResultsOK.Location = new System.Drawing.Point(892, 83);
             this.bEditOcrResultsOK.Name = "bEditOcrResultsOK";
             this.bEditOcrResultsOK.Size = new System.Drawing.Size(138, 26);
             this.bEditOcrResultsOK.TabIndex = 9;
@@ -143,28 +146,52 @@
             this.bEditOcrResultsOK.UseVisualStyleBackColor = true;
             this.bEditOcrResultsOK.Click += new System.EventHandler(this.bEditOcrResultsOK_Click);
             // 
+            // EditOcrResultsSplit
+            // 
+            this.EditOcrResultsSplit.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.EditOcrResultsSplit.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.EditOcrResultsSplit.Location = new System.Drawing.Point(0, 0);
+            this.EditOcrResultsSplit.Name = "EditOcrResultsSplit";
+            this.EditOcrResultsSplit.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // EditOcrResultsSplit.Panel1
+            // 
+            this.EditOcrResultsSplit.Panel1.Controls.Add(this.lbEditOcrResults);
+            this.EditOcrResultsSplit.Panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.splitContainer1_Panel1_Paint);
+            // 
+            // EditOcrResultsSplit.Panel2
+            // 
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsCommodityName);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.bEditOcrResultsOK);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsSellPrice);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsSupplyLevel);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsBuyPrice);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsSupply);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsDemand);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.pbEditOcrResultsOriginalImage);
+            this.EditOcrResultsSplit.Panel2.Controls.Add(this.tbEditOcrResultsDemandLevel);
+            this.EditOcrResultsSplit.Panel2MinSize = 75;
+            this.EditOcrResultsSplit.Size = new System.Drawing.Size(1079, 286);
+            this.EditOcrResultsSplit.SplitterDistance = 168;
+            this.EditOcrResultsSplit.TabIndex = 10;
+            // 
             // EditOcrResults
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1079, 286);
-            this.Controls.Add(this.bEditOcrResultsOK);
-            this.Controls.Add(this.tbEditOcrResultsSupplyLevel);
-            this.Controls.Add(this.tbEditOcrResultsSupply);
-            this.Controls.Add(this.tbEditOcrResultsDemandLevel);
-            this.Controls.Add(this.tbEditOcrResultsDemand);
-            this.Controls.Add(this.tbEditOcrResultsBuyPrice);
-            this.Controls.Add(this.tbEditOcrResultsSellPrice);
-            this.Controls.Add(this.tbEditOcrResultsCommodityName);
-            this.Controls.Add(this.pbEditOcrResultsOriginalImage);
-            this.Controls.Add(this.lbEditOcrResults);
-            this.MaximumSize = new System.Drawing.Size(1095, 538);
-            this.MinimumSize = new System.Drawing.Size(1095, 39);
+            this.Controls.Add(this.EditOcrResultsSplit);
+            this.MaximumSize = new System.Drawing.Size(1095, 2000);
+            this.MinimumSize = new System.Drawing.Size(1095, 325);
             this.Name = "EditOcrResults";
             this.Text = "EditOcrResults";
             ((System.ComponentModel.ISupportInitialize)(this.pbEditOcrResultsOriginalImage)).EndInit();
+            this.EditOcrResultsSplit.Panel1.ResumeLayout(false);
+            this.EditOcrResultsSplit.Panel2.ResumeLayout(false);
+            this.EditOcrResultsSplit.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.EditOcrResultsSplit)).EndInit();
+            this.EditOcrResultsSplit.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -180,5 +207,6 @@
         private System.Windows.Forms.TextBox tbEditOcrResultsSupplyLevel;
         private System.Windows.Forms.TextBox tbEditOcrResultsSupply;
         private System.Windows.Forms.Button bEditOcrResultsOK;
+        private System.Windows.Forms.SplitContainer EditOcrResultsSplit;
     }
 }

--- a/RegulatedNoise/EditOcrResults.cs
+++ b/RegulatedNoise/EditOcrResults.cs
@@ -90,5 +90,10 @@ namespace RegulatedNoise
             DialogResult= DialogResult.OK;
             Close();
         }
+
+        private void splitContainer1_Panel1_Paint(object sender, PaintEventArgs e)
+        {
+
+        }
     }
 }

--- a/RegulatedNoise/EditOcrResults.resx
+++ b/RegulatedNoise/EditOcrResults.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="pbEditOcrResultsOriginalImage.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="EditOcrResultsSplit.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Added a split-pane to fix resizing behavior and modified allowable window sizes.
